### PR TITLE
markdown refactor

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,4 +10,22 @@ class Post < ActiveRecord::Base
     validates :topic, presence: true
     validates :user, presence: true
 
+  def markdown_title
+    render_as_markdown title
+  end
+
+  def markdown_body
+    render_as_markdown body
+  end
+
+  def render_as_markdown(text)
+    renderer = Redcarpet::Render::HTML.new
+    extensions = {fenced_code_blocs: true}
+    redcarpet = Redcarpet::Markdown.new(renderer, extensions)
+    (redcarpet.render text).html_safe
+  end
+
+
+
+
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,10 +1,10 @@
 
 
-<h1><%= markdown @post.title %></h1>
+<h1><%= @post.markdown_title %></h1>
 
 <div class="row">
   <div class="col-md-8">
-    <p><%= markdown @post.body %></p>
+    <p><%= @post.markdown_body %></p>
   </div>
 
   <div class="col-md-4">


### PR DESCRIPTION
I prefer the application helper method for now. It is a straightforward way to apply markdown wherever I determine it is needed, and doesn't strike me as a particularly dangerous method to be able to use anywhere. The alternative of having methods defined in each topics, posts, and comments seems like it could get very heavy very fast, and only necessary if I want them to each have more specific capabilities. 
